### PR TITLE
Fix the top nav on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,6 +29,8 @@
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
+    --brand-yellow: 43 97% 59%;        /* HSL for #FEB92F */
+    --brand-yellow-foreground: 0 0% 0%; /* HSL for black */
   }
 
   .dark {
@@ -56,6 +58,8 @@
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
+    --brand-yellow: 43 97% 59%;
+    --brand-yellow-foreground: 0 0% 0%;
   }
 }
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,11 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
-import {CalendarIcon} from './icons/CalendarIcon';
+import { CalendarIcon } from "./icons/CalendarIcon";
 import Image from "next/image";
 import Link from "next/link";
+import { useState } from "react";
+import { Menu as MenuIcon, X as XIcon } from "lucide-react";
 
 const navLinks = [
   { href: "#", text: "Home" },
@@ -12,44 +16,93 @@ const navLinks = [
   { href: "#footer-contact", text: "Contact" },
 ];
 
-export const Header = () => (
-  <header className="sticky top-0 z-50 w-full border-b bg-[#FEB92F]">
-    <div className="container flex items-center justify-between h-16 px-4 md:px-6">
-      <Link
-        href="#"
-        className="flex items-center gap-2 text-lg font-semibold"
-        prefetch={false}
-      >
-        <Image
-          src="/VanJS.png"
-          alt="VanJS"
-          width={100}
-          height={64}
-          style={{
-            height: "64px",
-            objectFit: "cover",
-          }}
-        />
-      </Link>
-      <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
-        {navLinks.map((link) => (
-          <Link
-            key={link.text}
-            href={link.href}
-            className="hover:underline underline-offset-4"
-            prefetch={false}
-          >
-            {link.text}
-          </Link>
-        ))}
-      </nav>
+export const Header = () => {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
-      <Button asChild className="bg-secondary">
-        <Link href="https://lu.ma/vanjs" target="blank" prefetch={false}>
-          <CalendarIcon className="w-4 h-4 mr-2" />
-          Attend
+  const toggleMobileMenu = () => {
+    setIsMobileMenuOpen(!isMobileMenuOpen);
+  };
+
+  const closeMobileMenu = () => {
+    setIsMobileMenuOpen(false);
+  };
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b bg-[#FEB92F]">
+      <div className="container flex items-center justify-between h-16 px-4 md:px-6">
+        <Link
+          href="#"
+          className="flex items-center gap-2 text-lg font-semibold"
+          prefetch={false}
+          onClick={closeMobileMenu}
+        >
+          <Image
+            src="/VanJS.png"
+            alt="VanJS"
+            width={100}
+            height={64}
+            style={{
+              height: "64px",
+              objectFit: "cover",
+            }}
+          />
         </Link>
-      </Button>
-    </div>
-  </header>
-);
+
+        <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
+          {navLinks.map((link) => (
+            <Link
+              key={link.text}
+              href={link.href}
+              className="hover:underline underline-offset-4"
+              prefetch={false}
+            >
+              {link.text}
+            </Link>
+          ))}
+        </nav>
+
+        <div className="flex items-center gap-2">
+          <Button asChild className="bg-secondary hidden md:flex">
+            <Link href="https://lu.ma/vanjs" target="_blank" rel="noopener noreferrer" prefetch={false}>
+              <CalendarIcon className="w-4 h-4 mr-2" />
+              Attend
+            </Link>
+          </Button>
+
+          <button
+            type="button"
+            onClick={toggleMobileMenu}
+            className="md:hidden p-2 text-gray-700 hover:text-black focus:outline-none focus:ring-2 focus:ring-inset focus:ring-black"
+            aria-label="Toggle menu"
+          >
+            {isMobileMenuOpen ? <XIcon size={24} /> : <MenuIcon size={24} />}
+          </button>
+        </div>
+      </div>
+
+      {isMobileMenuOpen && (
+        <div className="md:hidden absolute top-16 left-0 w-full bg-brand-yellow shadow-lg z-40">
+          <nav className="flex flex-col items-start p-4 space-y-2">
+            {navLinks.map((link) => (
+              <Link
+                key={link.text}
+                href={link.href}
+                className="block w-full px-3 py-2 rounded-md text-base font-medium text-black hover:bg-black hover:text-brand-yellow"
+                prefetch={false}
+                onClick={closeMobileMenu}
+              >
+                {link.text}
+              </Link>
+            ))}
+            <Button asChild className="w-full mt-2 bg-secondary hover:bg-secondary/80">
+              <Link href="https://lu.ma/vanjs" target="_blank" rel="noopener noreferrer" prefetch={false} onClick={closeMobileMenu}>
+                <CalendarIcon className="w-4 h-4 mr-2" />
+                Attend
+              </Link>
+            </Button>
+          </nav>
+        </div>
+      )}
+    </header>
+  );
+};


### PR DESCRIPTION
1.  **Mobile Navigation:**
    *   **Observation:** The main navigation links (`Home`, `Upcoming`, `Past`, etc.) are hidden on smaller screens, and no alternative (e.g., hamburger menu) is provided. Only the "VanJS" logo and "Attend" button are visible.
    *   **Suggestion:** Implement a mobile-friendly navigation pattern (e.g., hamburger icon that toggles a dropdown or off-canvas menu) to ensure all navigation links are accessible on all device sizes. This is critical for usability.
    
After:
<img width="864" alt="image" src="https://github.com/user-attachments/assets/5021ecab-d1be-4cab-8cc6-84f8cbb6999b" />
